### PR TITLE
Solve deprecations in DependencyInjection/Configuration.php and Controller/DebugController.php

### DIFF
--- a/Controller/DebugController.php
+++ b/Controller/DebugController.php
@@ -6,9 +6,9 @@ use Google_Service_AnalyticsReporting_DateRange;
 use Google_Service_AnalyticsReporting_GetReportsRequest;
 use Google_Service_AnalyticsReporting_Metric;
 use Google_Service_AnalyticsReporting_ReportRequest;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\Routing\Annotation\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Class DebugController

--- a/Controller/DebugController.php
+++ b/Controller/DebugController.php
@@ -7,14 +7,14 @@ use Google_Service_AnalyticsReporting_GetReportsRequest;
 use Google_Service_AnalyticsReporting_Metric;
 use Google_Service_AnalyticsReporting_ReportRequest;
 use Symfony\Component\Routing\Annotation\Template;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Class DebugController
  * @package MediaFigaro\GoogleAnalyticsApi\Controller
  */
-class DebugController extends Controller
+class DebugController extends AbstractController
 {
     /**
      * @Route("{viewId}")

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('google_analytics_api');
+        $treeBuilder = new TreeBuilder('google_analytics_api');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
- Give a parameter to the Treebuilder instance for the root node name. Old way is deprecated
- Change the route and template components from Sensio for the Symfony ones as the Sensio ones are deprecated
- Change the Symfony Controller for the Symfony AbstractController since the Controller is deprecated